### PR TITLE
Fix likely typo in Item Restorations

### DIFF
--- a/ub/items/setup_item_restorations.tpa
+++ b/ub/items/setup_item_restorations.tpa
@@ -224,7 +224,7 @@ BEGIN
 
   // Add to Trademeet nobleman merchant's inventory.
   COPY_EXISTING "trmer02.sto" "override"
-    ADD_STORE_ITEM "plat05" AFTER "plat10" #0 #0 #0 "identified" #1
+    ADD_STORE_ITEM "plat08" AFTER "plat10" #0 #0 #0 "identified" #1
 
 
   /* The Whistling Sword */


### PR DESCRIPTION
plat08.itm was created but never used
plat05.itm is already assigned to tazok.cre